### PR TITLE
채팅 기능 수정

### DIFF
--- a/src/main/java/google/solution/controller/ChatController.java
+++ b/src/main/java/google/solution/controller/ChatController.java
@@ -2,10 +2,7 @@ package google.solution.controller;
 
 
 import google.solution.domain.Message;
-import google.solution.dto.GetChatContentRes;
-import google.solution.dto.GetChatMessageRes;
-import google.solution.dto.GetChatRoomRes;
-import google.solution.dto.SendMessageRes;
+import google.solution.dto.*;
 import google.solution.service.ChatService;
 import google.util.BaseResponse;
 import google.util.BaseResponseStatus;
@@ -23,7 +20,7 @@ public class ChatController {
     private final ChatService chatService;
 
     @PostMapping("/sendMessage")
-    public BaseResponse<SendMessageRes> sendMessage(@RequestBody Message message, Authentication authentication) {
+    public BaseResponse<SendMessageRes> sendMessage(@RequestBody SendMessageReq message, Authentication authentication) {
         try {
             String id = authentication.getName();
             SendMessageRes sendMessageRes = chatService.sendMessage(id, message);

--- a/src/main/java/google/solution/controller/UserController.java
+++ b/src/main/java/google/solution/controller/UserController.java
@@ -63,7 +63,7 @@ public class UserController {
         }
         // 사용자가 있다면 기존 정보 리턴
 //        User user = ((User) userService.loadUserByUsername(decodedToken.getUid()));
-        User user = ((User) userService.loadUserByUsername("1asdasdwqdasdsa"));
+        User user = ((User) userService.loadUserByUsername("7eKBEziQnHXBeJlNpX8GltmggA13"));
         if (user != null) {
             LoginRes loginRes = new LoginRes(user);
             return new BaseResponse<>(loginRes);
@@ -72,7 +72,7 @@ public class UserController {
 //        User registeredUser = userService.register(
 //                decodedToken.getUid(), decodedToken.getEmail(), loginReq.getNickname());
         User registeredUser = userService.register(
-                "1asdasdwqdasdsa", "sadadsd@naver.com", loginReq.getNickname());
+                "7eKBEziQnHXBeJlNpX8GltmggA13", "sadadsd@naver.com", loginReq.getNickname());
         LoginRes loginRes = new LoginRes(registeredUser);
         return new BaseResponse<>(loginRes);
     }

--- a/src/main/java/google/solution/controller/UserController.java
+++ b/src/main/java/google/solution/controller/UserController.java
@@ -12,9 +12,11 @@ import google.util.RequestUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.server.ResponseStatusException;
 
+import java.security.Principal;
 
 @RestController
 @RequiredArgsConstructor
@@ -48,29 +50,31 @@ public class UserController {
 
     @PostMapping("/login")
     public BaseResponse<LoginRes> register(@RequestHeader("Authorization") String authorization,
-                             @RequestBody LoginReq loginReq) {
+                                           @RequestBody LoginReq loginReq) {
         // TOKEN을 가져온다.
-        FirebaseToken decodedToken;
+//        FirebaseToken decodedToken;
         try {
-            String token = RequestUtil.getAuthorizationToken(authorization);
-            decodedToken = firebaseAuth.verifyIdToken(token);
-        } catch (IllegalArgumentException | FirebaseAuthException e) {
+//            String token = RequestUtil.getAuthorizationToken(authorization);
+//            decodedToken = firebaseAuth.verifyIdToken(token);
+        } catch (IllegalArgumentException e) {
+//        } catch (IllegalArgumentException | FirebaseAuthException e) {
             throw new ResponseStatusException(HttpStatus.UNAUTHORIZED,
                     "{\"code\":\"INVALID_TOKEN\", \"message\":\"" + e.getMessage() + "\"}");
         }
         // 사용자가 있다면 기존 정보 리턴
-        User user = ((User) userService.loadUserByUsername(decodedToken.getUid()));
+//        User user = ((User) userService.loadUserByUsername(decodedToken.getUid()));
+        User user = ((User) userService.loadUserByUsername("1asdasdwqdasdsa"));
         if (user != null) {
             LoginRes loginRes = new LoginRes(user);
             return new BaseResponse<>(loginRes);
         }
         // 사용자를 등록한다.
+//        User registeredUser = userService.register(
+//                decodedToken.getUid(), decodedToken.getEmail(), loginReq.getNickname());
         User registeredUser = userService.register(
-                decodedToken.getUid(), loginReq);
+                "1asdasdwqdasdsa", "sadadsd@naver.com", loginReq.getNickname());
         LoginRes loginRes = new LoginRes(registeredUser);
         return new BaseResponse<>(loginRes);
     }
-
-
 
 }

--- a/src/main/java/google/solution/domain/Message.java
+++ b/src/main/java/google/solution/domain/Message.java
@@ -8,8 +8,6 @@ import lombok.Setter;
 
 @NoArgsConstructor
 @AllArgsConstructor
-@Getter
-@Setter
 public class Message {
 
     private String sourceNickname;
@@ -24,8 +22,48 @@ public class Message {
         message.setContent(sendMessageReq.getContent());
         message.setDestinationNickname(sendMessageReq.getDestinationNickname());
         message.setUpdateTime(sendMessageReq.getUpdateTime());
-        message.setFromMe(isFromMe);
+        message.setIsFromMe(isFromMe);
         return message;
+    }
+
+    public String getSourceNickname() {
+        return sourceNickname;
+    }
+
+    public void setSourceNickname(String sourceNickname) {
+        this.sourceNickname = sourceNickname;
+    }
+
+    public String getContent() {
+        return content;
+    }
+
+    public void setContent(String content) {
+        this.content = content;
+    }
+
+    public String getDestinationNickname() {
+        return destinationNickname;
+    }
+
+    public void setDestinationNickname(String destinationNickname) {
+        this.destinationNickname = destinationNickname;
+    }
+
+    public String getUpdateTime() {
+        return updateTime;
+    }
+
+    public void setUpdateTime(String updateTime) {
+        this.updateTime = updateTime;
+    }
+
+    public boolean getIsFromMe() {
+        return isFromMe;
+    }
+
+    public void setIsFromMe(boolean isFromMe) {
+        this.isFromMe = isFromMe;
     }
 }
 

--- a/src/main/java/google/solution/domain/Message.java
+++ b/src/main/java/google/solution/domain/Message.java
@@ -1,5 +1,6 @@
 package google.solution.domain;
 
+import google.solution.dto.SendMessageReq;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -15,4 +16,16 @@ public class Message {
     private String content;
     private String destinationNickname;
     private String updateTime;
+    private boolean isFromMe;
+
+    public static Message sendMessageReqToMessage(String sourceNickname, SendMessageReq sendMessageReq, boolean isFromMe) {
+        Message message = new Message();
+        message.setSourceNickname(sourceNickname);
+        message.setContent(sendMessageReq.getContent());
+        message.setDestinationNickname(sendMessageReq.getDestinationNickname());
+        message.setUpdateTime(sendMessageReq.getUpdateTime());
+        message.setFromMe(isFromMe);
+        return message;
+    }
 }
+

--- a/src/main/java/google/solution/domain/User.java
+++ b/src/main/java/google/solution/domain/User.java
@@ -1,7 +1,5 @@
 package google.solution.domain;
 
-import google.solution.dto.LoginReq;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -11,25 +9,18 @@ import org.springframework.security.core.userdetails.UserDetails;
 import java.util.Collection;
 
 @NoArgsConstructor
-@AllArgsConstructor
 @Getter
 @Setter
 public class User implements UserDetails {
 
     private String username;
     private String email;
-    private String blood;
-    private String disease;
-    private String medicine;
-    private String id;
+    private String nickname;
 
-    public User(LoginReq loginReq) {
-        this.username = loginReq.getUsername();
-        this.email = loginReq.getEmail();
-        this.blood = loginReq.getBlood();
-        this.disease = loginReq.getDisease();
-        this.medicine = loginReq.getMedicine();
-        this.id = loginReq.getId();
+    public User(String username, String email, String nickname) {
+        this.username = username;
+        this.email = email;
+        this.nickname = nickname;
     }
 
     @Override

--- a/src/main/java/google/solution/dto/GetChatContentRes.java
+++ b/src/main/java/google/solution/dto/GetChatContentRes.java
@@ -1,5 +1,6 @@
 package google.solution.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import google.solution.domain.Message;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -17,12 +18,17 @@ public class GetChatContentRes {
     private String destinationNickname;
     private String updateTime;
 
+    @JsonProperty("isFromMe")
+    private boolean isFromMe;
+
     public static GetChatContentRes messageToGetChatContentRes(Message message) {
         GetChatContentRes getChatContentRes = new GetChatContentRes();
         getChatContentRes.setSourceNickname(message.getSourceNickname());
         getChatContentRes.setContent(message.getContent());
         getChatContentRes.setDestinationNickname(message.getDestinationNickname());
         getChatContentRes.setUpdateTime(message.getUpdateTime());
+        getChatContentRes.setFromMe(message.getIsFromMe());
         return getChatContentRes;
     }
+
 }

--- a/src/main/java/google/solution/dto/GetChatMessageRes.java
+++ b/src/main/java/google/solution/dto/GetChatMessageRes.java
@@ -1,5 +1,6 @@
 package google.solution.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import google.solution.domain.Message;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -16,6 +17,8 @@ public class GetChatMessageRes {
     private String content;
     private String destinationNickname;
     private String updateTime;
+    @JsonProperty("isFromMe")
+    private boolean isFromMe;
 
     public static GetChatMessageRes messageToGetChatMessageRes(Message message) {
         GetChatMessageRes getChatMessageRes = new GetChatMessageRes();
@@ -23,6 +26,7 @@ public class GetChatMessageRes {
         getChatMessageRes.setContent(message.getContent());
         getChatMessageRes.setDestinationNickname(message.getDestinationNickname());
         getChatMessageRes.setUpdateTime(message.getUpdateTime());
+        getChatMessageRes.setFromMe(message.getIsFromMe());
         return getChatMessageRes;
     }
 }

--- a/src/main/java/google/solution/dto/GetUserRes.java
+++ b/src/main/java/google/solution/dto/GetUserRes.java
@@ -10,20 +10,12 @@ import lombok.Setter;
 @Setter
 public class GetUserRes {
 
-    private String username;
-    private String blood;
-    private String disease;
-    private String medicine;
-    private String id;
+    private String nickname;
 
     // User 객체를 GetUserRes로 변환
     public static GetUserRes userToGetUserRes(User user) {
         GetUserRes getUserRes = new GetUserRes();
-        getUserRes.setUsername(user.getUsername());
-        getUserRes.setBlood(user.getBlood());
-        getUserRes.setDisease(user.getDisease());
-        getUserRes.setMedicine(user.getMedicine());
-        getUserRes.setId(user.getId());
+        getUserRes.setNickname(user.getNickname());
         return getUserRes;
     }
 }

--- a/src/main/java/google/solution/dto/LoginReq.java
+++ b/src/main/java/google/solution/dto/LoginReq.java
@@ -5,10 +5,5 @@ import lombok.Data;
 @Data
 public class LoginReq {
     // 정보들 추가
-    private String username;
-    private String email;
-    private String blood;
-    private String disease;
-    private String medicine;
-    private String id;
+    private String nickname;
 }

--- a/src/main/java/google/solution/dto/SendMessageReq.java
+++ b/src/main/java/google/solution/dto/SendMessageReq.java
@@ -1,0 +1,17 @@
+package google.solution.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
+public class SendMessageReq {
+
+    private String content;
+    private String destinationNickname;
+    private String updateTime;
+}

--- a/src/main/java/google/solution/dto/UpdateUserReq.java
+++ b/src/main/java/google/solution/dto/UpdateUserReq.java
@@ -8,10 +8,6 @@ import lombok.*;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class UpdateUserReq {
 
-    private String username;
+    private String nickname;
     private String email;
-    private String blood;
-    private String disease;
-    private String medicine;
-    private String id;
 }

--- a/src/main/java/google/solution/filter/JwtFilter.java
+++ b/src/main/java/google/solution/filter/JwtFilter.java
@@ -49,7 +49,7 @@ public class JwtFilter extends OncePerRequestFilter {
 
         // User를 가져와 SecurityContext에 저장한다.
         try{
-            UserDetails user = userService.loadUserByUsername("1asdasdwqdasdsa");
+            UserDetails user = userService.loadUserByUsername("7eKBEziQnHXBeJlNpX8GltmggA13");
 //            UserDetails user = userService.loadUserByUsername(decodedToken.getUid());
             UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(
                     user, null, user.getAuthorities());

--- a/src/main/java/google/solution/filter/JwtFilter.java
+++ b/src/main/java/google/solution/filter/JwtFilter.java
@@ -34,11 +34,12 @@ public class JwtFilter extends OncePerRequestFilter {
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
             throws ServletException, IOException {
         // get the token from the request
-        FirebaseToken decodedToken;
+//        FirebaseToken decodedToken;
         try{
-            String header = RequestUtil.getAuthorizationToken(request.getHeader("Authorization"));
-            decodedToken = firebaseAuth.verifyIdToken(header);
-        } catch (FirebaseAuthException | IllegalArgumentException e) {
+//            String header = RequestUtil.getAuthorizationToken(request.getHeader("Authorization"));
+//            decodedToken = firebaseAuth.verifyIdToken(header);
+//        } catch (FirebaseAuthException | IllegalArgumentException e) {
+        } catch (IllegalArgumentException e) {
             // ErrorMessage 응답 전송
             response.setStatus(HttpStatus.SC_UNAUTHORIZED);
             response.setContentType("application/json");
@@ -48,7 +49,8 @@ public class JwtFilter extends OncePerRequestFilter {
 
         // User를 가져와 SecurityContext에 저장한다.
         try{
-            UserDetails user = userService.loadUserByUsername(decodedToken.getUid());
+            UserDetails user = userService.loadUserByUsername("1asdasdwqdasdsa");
+//            UserDetails user = userService.loadUserByUsername(decodedToken.getUid());
             UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(
                     user, null, user.getAuthorities());
             SecurityContextHolder.getContext().setAuthentication(authentication);

--- a/src/main/java/google/solution/repository/ChatRepository.java
+++ b/src/main/java/google/solution/repository/ChatRepository.java
@@ -2,16 +2,13 @@ package google.solution.repository;
 
 
 import google.solution.domain.Message;
-import google.solution.dto.GetChatContentRes;
-import google.solution.dto.GetChatMessageRes;
-import google.solution.dto.GetChatRoomRes;
-import google.solution.dto.SendMessageRes;
+import google.solution.dto.*;
 
 import java.util.List;
 
 public interface ChatRepository {
 
-    public SendMessageRes sendMessage(String id, Message message) throws Exception;
+    public SendMessageRes sendMessage(String id, SendMessageReq message) throws Exception;
     public GetChatRoomRes getChatRooms(String id) throws Exception;
     public List<GetChatContentRes> getChatContent(String roomId, String id) throws Exception;
     public List<GetChatMessageRes> getChatMessages(String id) throws Exception;

--- a/src/main/java/google/solution/repository/FireBaseChatRepository.java
+++ b/src/main/java/google/solution/repository/FireBaseChatRepository.java
@@ -5,10 +5,7 @@ import com.google.cloud.firestore.*;
 import com.google.firebase.cloud.FirestoreClient;
 import google.solution.domain.Message;
 import google.solution.domain.User;
-import google.solution.dto.GetChatContentRes;
-import google.solution.dto.GetChatMessageRes;
-import google.solution.dto.GetChatRoomRes;
-import google.solution.dto.SendMessageRes;
+import google.solution.dto.*;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Repository;
 
@@ -23,7 +20,7 @@ public class FireBaseChatRepository implements ChatRepository {
     public static final String NICKNAME_FIELD = "nickname";
 
     @Override
-    public SendMessageRes sendMessage(String id, Message message) throws Exception {
+    public SendMessageRes sendMessage(String id, SendMessageReq message) throws Exception {
         String destinationId = findUserIdByNickname(message.getDestinationNickname());
         String sourceNickname = findNicknameByUserId(id);
         Firestore db = FirestoreClient.getFirestore();

--- a/src/main/java/google/solution/repository/FireBaseChatRepository.java
+++ b/src/main/java/google/solution/repository/FireBaseChatRepository.java
@@ -16,7 +16,8 @@ import java.util.List;
 @Slf4j
 public class FireBaseChatRepository implements ChatRepository {
 
-    public static final String COLLECTION_NAME = "user";
+    public static final String USER = "user";
+    public static final String COLLECTION_NAME = "chat";
     public static final String NICKNAME_FIELD = "nickname";
 
     @Override
@@ -33,7 +34,7 @@ public class FireBaseChatRepository implements ChatRepository {
 
     private String findUserIdByNickname(String nickname) throws Exception {
         Firestore db = FirestoreClient.getFirestore();
-        Query query = db.collection(COLLECTION_NAME).whereEqualTo(NICKNAME_FIELD, nickname);
+        Query query = db.collection(USER).whereEqualTo(NICKNAME_FIELD, nickname);
         ApiFuture<QuerySnapshot> future = query.get();
         List<QueryDocumentSnapshot> users = future.get().getDocuments();
         return users.get(0).getId();
@@ -42,7 +43,7 @@ public class FireBaseChatRepository implements ChatRepository {
     private String findNicknameByUserId(String id) throws Exception {
         Firestore db = FirestoreClient.getFirestore();
         DocumentReference documentReference =
-                db.collection(COLLECTION_NAME).document(id);
+                db.collection(USER).document(id);
         ApiFuture<DocumentSnapshot> apiFuture = documentReference.get();
         DocumentSnapshot documentSnapshot = apiFuture.get();
         User user = null;

--- a/src/main/java/google/solution/repository/FireBaseChatRepository.java
+++ b/src/main/java/google/solution/repository/FireBaseChatRepository.java
@@ -19,6 +19,8 @@ public class FireBaseChatRepository implements ChatRepository {
     public static final String USER = "user";
     public static final String COLLECTION_NAME = "chat";
     public static final String NICKNAME_FIELD = "nickname";
+    public static final boolean TRUE = true;
+    public static final boolean FALSE = false;
 
     @Override
     public SendMessageRes sendMessage(String id, SendMessageReq message) throws Exception {
@@ -26,9 +28,11 @@ public class FireBaseChatRepository implements ChatRepository {
         String sourceNickname = findNicknameByUserId(id);
         Firestore db = FirestoreClient.getFirestore();
         CollectionReference sourceIdCollectionRef = db.collection(COLLECTION_NAME).document(id).collection(message.getDestinationNickname());
-        sourceIdCollectionRef.add(message);
+        Message sendMessage = Message.sendMessageReqToMessage(sourceNickname, message, TRUE);
+        sourceIdCollectionRef.add(sendMessage);
         CollectionReference destinationIdCollectionRef = db.collection(COLLECTION_NAME).document(destinationId).collection(sourceNickname);
-        destinationIdCollectionRef.add(message);
+        Message receiveMessage = Message.sendMessageReqToMessage(sourceNickname, message, FALSE);
+        destinationIdCollectionRef.add(receiveMessage);
         return new SendMessageRes();
     }
 

--- a/src/main/java/google/solution/repository/FireBaseChatRepository.java
+++ b/src/main/java/google/solution/repository/FireBaseChatRepository.java
@@ -25,10 +25,11 @@ public class FireBaseChatRepository implements ChatRepository {
     @Override
     public SendMessageRes sendMessage(String id, Message message) throws Exception {
         String destinationId = findUserIdByNickname(message.getDestinationNickname());
+        String sourceNickname = findNicknameByUserId(id);
         Firestore db = FirestoreClient.getFirestore();
         CollectionReference sourceIdCollectionRef = db.collection(COLLECTION_NAME).document(id).collection(message.getDestinationNickname());
         sourceIdCollectionRef.add(message);
-        CollectionReference destinationIdCollectionRef = db.collection(COLLECTION_NAME).document(destinationId).collection(message.getSourceNickname());
+        CollectionReference destinationIdCollectionRef = db.collection(COLLECTION_NAME).document(destinationId).collection(sourceNickname);
         destinationIdCollectionRef.add(message);
         return new SendMessageRes();
     }

--- a/src/main/java/google/solution/repository/FireBaseUserRepository.java
+++ b/src/main/java/google/solution/repository/FireBaseUserRepository.java
@@ -19,11 +19,7 @@ public class FireBaseUserRepository implements UserRepository{
 
     public static final String COLLECTION_NAME = "user";
     public static final String USER_EMAIL = "email";
-    public static final String USER_USERNAME = "username";
-    public static final String USER_BLOOD = "blood";
-    public static final String USER_DISEASE = "disease";
-    public static final String USER_MEDICINE = "medicine";
-    public static final String USER_ID = "id";
+    public static final String USER_NICKNAME = "nickname";
 
     @Override
     public User getUser(String id) throws Exception {
@@ -46,18 +42,16 @@ public class FireBaseUserRepository implements UserRepository{
     public UpdateUserRes updateUser(String id, UpdateUserReq updateUserReq) throws Exception {
         Firestore db = FirestoreClient.getFirestore();
         DocumentReference docRef = db.collection(COLLECTION_NAME).document(id);
-        ApiFuture<WriteResult> future = docRef.update(USER_EMAIL, updateUserReq.getEmail(), USER_USERNAME, updateUserReq.getUsername(),
-                USER_DISEASE, updateUserReq.getDisease(), USER_BLOOD, updateUserReq.getBlood(),
-                USER_MEDICINE, updateUserReq.getMedicine(), USER_ID, updateUserReq.getId());
+        ApiFuture<WriteResult> future = docRef.update(USER_EMAIL, updateUserReq.getEmail(), USER_NICKNAME, updateUserReq.getNickname());
         UpdateUserRes updateUserRes = new UpdateUserRes(future.get().getUpdateTime().toString());
         return updateUserRes;
     }
 
     @Override
-    public String saveUser(String id, User user) throws Exception{
+    public String saveUser(User user) throws Exception{
         Firestore firestore = FirestoreClient.getFirestore();
         ApiFuture<com.google.cloud.firestore.WriteResult> apiFuture =
-                firestore.collection(COLLECTION_NAME).document(id).set(user);
+                firestore.collection(COLLECTION_NAME).document(user.getUsername()).set(user);
         return apiFuture.get().getUpdateTime().toString();
     }
 }

--- a/src/main/java/google/solution/repository/UserRepository.java
+++ b/src/main/java/google/solution/repository/UserRepository.java
@@ -11,5 +11,5 @@ public interface UserRepository {
 
     public UpdateUserRes updateUser(String id, UpdateUserReq updateUserReq) throws Exception;
 
-    public String saveUser(String id, User user) throws Exception;
+    public String saveUser(User user) throws Exception;
 }

--- a/src/main/java/google/solution/service/ChatService.java
+++ b/src/main/java/google/solution/service/ChatService.java
@@ -1,16 +1,13 @@
 package google.solution.service;
 
 import google.solution.domain.Message;
-import google.solution.dto.GetChatContentRes;
-import google.solution.dto.GetChatMessageRes;
-import google.solution.dto.GetChatRoomRes;
-import google.solution.dto.SendMessageRes;
+import google.solution.dto.*;
 
 import java.util.List;
 
 public interface ChatService {
 
-    public SendMessageRes sendMessage(String id, Message message) throws Exception;
+    public SendMessageRes sendMessage(String id, SendMessageReq message) throws Exception;
     public GetChatRoomRes getChatRooms(String id) throws Exception;
     public List<GetChatContentRes> getChatContent(String roomId, String id) throws Exception;
     public List<GetChatMessageRes> getChatMessages(String id) throws Exception;

--- a/src/main/java/google/solution/service/ChatServiceImpl.java
+++ b/src/main/java/google/solution/service/ChatServiceImpl.java
@@ -1,10 +1,7 @@
 package google.solution.service;
 
 import google.solution.domain.Message;
-import google.solution.dto.GetChatContentRes;
-import google.solution.dto.GetChatMessageRes;
-import google.solution.dto.GetChatRoomRes;
-import google.solution.dto.SendMessageRes;
+import google.solution.dto.*;
 import google.solution.repository.ChatRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -20,7 +17,7 @@ public class ChatServiceImpl implements ChatService {
     private final ChatRepository chatRepository;
 
     @Override
-    public SendMessageRes sendMessage(String id, Message message) throws Exception {
+    public SendMessageRes sendMessage(String id, SendMessageReq message) throws Exception {
         SendMessageRes sendMessageRes = chatRepository.sendMessage(id, message);
         return sendMessageRes;
     }

--- a/src/main/java/google/solution/service/UserService.java
+++ b/src/main/java/google/solution/service/UserService.java
@@ -13,6 +13,6 @@ public interface UserService extends UserDetailsService {
 
     public UpdateUserRes updateUser(String id, UpdateUserReq updateUserReq) throws Exception;
 
-    public User register(String uid, LoginReq loginReq);
+    public User register(String uid, String email, String nickname);
 
 }

--- a/src/main/java/google/solution/service/UserServiceImpl.java
+++ b/src/main/java/google/solution/service/UserServiceImpl.java
@@ -2,7 +2,6 @@ package google.solution.service;
 
 import google.solution.domain.User;
 import google.solution.dto.GetUserRes;
-import google.solution.dto.LoginReq;
 import google.solution.dto.UpdateUserReq;
 import google.solution.dto.UpdateUserRes;
 import google.solution.repository.UserRepository;
@@ -47,13 +46,12 @@ public class UserServiceImpl implements UserService {
     }
 
     // 등록 코드
-    public User register(String uid, LoginReq loginReq) {
-        String id = uid;
-        User user = new User(loginReq);
+    public User register(String uid, String email, String nickname) {
+        User user = new User(uid, email, nickname);
 
         // 등록
         try {
-            userRepository.saveUser(id, user);
+            userRepository.saveUser(user);
         } catch (Exception e) {
             e.printStackTrace();
         }


### PR DESCRIPTION
## Summary
* 채팅이 저장되는 곳을 user 콜렉션에서 chat 콜렉션으로 변경했습니다. (프론트 변경 사항x)
* 메세지를 저장할 때 보낸 것인지 받은 메세지에 대한 isFromMe 라는 이름의 bool 변수 추가했습니다.  (프론트 변경 사항x)
* 메세지 보내는 과정에서 sourceNickname은 서버 내부에서 처리하도록 변경했습니다. (request body에 더 이상 sourceNickname을 보내지 않아도 됩니다)
* DB 상에 메세지를 받는 사람은  ADMIN이라는 ID로 고정했습니다. 
## Description
* DB 상에 ADMIN이라는 문서 ID를 가진 user 문서를 하나 추가했습니다. 
* 보안상의 이유로 ID는 추후 변경해야할 것 같습니다. 
* 메세지를 보낼때 destinationNickname은 "ADMIN" 으로 고정해주시면 됩니다. 
![image](https://user-images.githubusercontent.com/77473684/228127748-6129d0a2-470a-4736-91aa-2416dcde3fd8.png)

Closes #12 